### PR TITLE
ARM64 Docker Image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -29,6 +32,7 @@ jobs:
       - name: Build and push to GHCR
         uses: docker/build-push-action@v5
         with:
+          platforms: linux/amd64,linux/arm64
           context: .
           file: ./Containerfile
           push: true


### PR DESCRIPTION
Es ist zwar ziemlich simpel, sich selbst ein Image für ARM64 zu bauen, aber ich denke, es kann trotzdem nicht schaden, eines anzubieten.