### PR TITLE
docker image unknown/unknow fix

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -45,3 +45,4 @@ jobs:
           file: ./Containerfile
           push: true
           tags: ${{ env.TAGS }}
+          provenance: false

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -42,7 +42,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
-          context: .
           file: ./Containerfile
           push: true
           tags: ${{ env.TAGS }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,9 +16,6 @@ jobs:
       packages: write
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -39,7 +39,7 @@ jobs:
           fi
 
       - name: Build and push to GHCR
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           context: .


### PR DESCRIPTION
I have changed the Github action a bit:
- Removed unnecessary steps
- Updated "docker/build-push-action" to the current version
- Set the "provenance" option to "false" within the "docker/build-push-action" step so that the image with OS/Arch "unknown/unknown" is no longer created.