### PR TITLE
Github Actions: Cleanup unused and untagged image versions in GHCR

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   docker:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -33,9 +33,9 @@ jobs:
         id: vars
         run: |
           if [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "TAGS=ghcr.io/robertzaage/grobro:latest,ghcr.io/robertzaage/grobro:${{ github.ref_name }}" >> $GITHUB_ENV
+            echo "TAGS=ghcr.io/wastlbava/grobro:latest,ghcr.io/wastlbava/grobro:${{ github.ref_name }}" >> $GITHUB_ENV
           else
-            echo "TAGS=ghcr.io/robertzaage/grobro:dev" >> $GITHUB_ENV
+            echo "TAGS=ghcr.io/wastlbava/grobro:dev" >> $GITHUB_ENV
           fi
 
       - name: Build and push to GHCR

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   docker:
@@ -34,9 +33,9 @@ jobs:
         id: vars
         run: |
           if [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "TAGS=ghcr.io/wastlbava/grobro:latest,ghcr.io/wastlbava/grobro:${{ github.ref_name }}" >> $GITHUB_ENV
+            echo "TAGS=ghcr.io/robertzaage/grobro:latest,ghcr.io/robertzaage/grobro:${{ github.ref_name }}" >> $GITHUB_ENV
           else
-            echo "TAGS=ghcr.io/wastlbava/grobro:dev" >> $GITHUB_ENV
+            echo "TAGS=ghcr.io/robertzaage/grobro:dev" >> $GITHUB_ENV
           fi
 
       - name: Build and push to GHCR

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -14,8 +14,5 @@ jobs:
     steps:
       - uses: dataaxiom/ghcr-cleanup-action@v1
         with:
-            # token: ${{ secrets.GITHUB_TOKEN }}
-            # owner: wastlbava
-            # repository: GroBro
-            package: grobro
-            dry-run: true
+          package: grobro
+          # dry-run: true

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,21 @@
+name: Build and Push Container Image to GHCR
+
+on:
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+            token: ${{ secrets.GITHUB_TOKEN }}
+            owner: wastlbava
+            repository: GroBro
+            package: grobro
+            dry-run: true

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,4 +1,4 @@
-name: Build and Push Container Image to GHCR
+name: Cleanup GHCR images
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
       packages: write
 
     steps:

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -13,5 +13,7 @@ jobs:
     steps:
       - uses: dataaxiom/ghcr-cleanup-action@v1
         with:
+          owner: robertzaage
+          repository: GroBro
           package: grobro
           dry-run: true

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: dataaxiom/ghcr-cleanup-action@v1
         with:
           package: grobro
-          # dry-run: true
+          dry-run: true

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -17,5 +17,5 @@ jobs:
             # token: ${{ secrets.GITHUB_TOKEN }}
             # owner: wastlbava
             # repository: GroBro
-            # package: grobro
+            package: grobro
             dry-run: true

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - uses: dataaxiom/ghcr-cleanup-action@v1
         with:
-            token: ${{ secrets.GITHUB_TOKEN }}
-            owner: wastlbava
-            repository: GroBro
-            package: grobro
+            # token: ${{ secrets.GITHUB_TOKEN }}
+            # owner: wastlbava
+            # repository: GroBro
+            # package: grobro
             dry-run: true


### PR DESCRIPTION
Due to the fact that the storage space of the GHCR is limited, I have written a Github action that cleans up image versions that are unused and untagged.

Currently the action is in dry-run mode, so nothing is deleted and the action is only started manually.
If deletion is active (dry-run: false), not all untagged versions are deleted, as these are used by the tagged versions due to the multi-arch build.

I have tested it with this action run before and it would not delete any version that is in use from a tag.
https://github.com/wastlbava/GroBro/actions/runs/14681652622/job/41205035479

