### PR TITLE
Github Actions: Cleanup GHCR images

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -18,4 +18,3 @@ jobs:
           owner: robertzaage
           repository: GroBro
           package: grobro
-          dry-run: true

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -2,6 +2,8 @@ name: Cleanup GHCR images
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "40 20 * * *"
 
 jobs:
   cleanup:


### PR DESCRIPTION
I have checked the outputs of the Github action.
https://github.com/robertzaage/GroBro/actions/runs/14681974392

The action would not delete any image or package versions that are still in use by tags.

I think we can remove the dry-run mode now.

I have also added a schedule so that the action runs daily at 8:40pm UTC.
I would leave the action start on workflow_dispatch in so that the action can also be started manually.



