### PR TITLE
Add actions for setting power in smart power mode (NOAH)

### DIFF
--- a/grobro/tools/reg_msg_decoder.py
+++ b/grobro/tools/reg_msg_decoder.py
@@ -93,6 +93,14 @@ def noah_decode_inverter(body: bytes):
     model_id = body[-2:].hex()
     return {"action": "inverter_config", "model_id": model_id}
 
+def noah_decode_smartpowerset(body: bytes):
+    pos = body.find(b"\x01\x36\x01\x38")
+    if pos == -1 or pos + 10 > len(body):
+        return None
+    setdown = struct.unpack(">H", body[pos + 4 : pos + 6])[0]
+    setup = struct.unpack(">H", body[pos + 6 : pos + 8])[0]
+    return {"action": "smart_powerset", "set_power_up": setup, "set_power_down": setdown}
+
 def decode_noah(mtype: int, payload: bytes):
     body = payload
     for fn in (
@@ -101,6 +109,7 @@ def decode_noah(mtype: int, payload: bytes):
         noah_decode_output_limit,
         noah_decode_datetime,
         noah_decode_inverter,
+        noah_decode_smartpowerset,
     ):
         res = fn(body)
         if res:


### PR DESCRIPTION
I analyzed and added how to manage power while in smart power mode ("Eigenverbrauchsmodus"), connected to a Shelly 3EM. Growatt cloud sends messages indicating the amount of power to lower or rise ... example:

```
00000000  00 01 00 07 00 2A 01 10 30 50 56 50 xx xx xx xx   |.....*..0PVPxxxx|
00000010  xx xx xx xx xx xx xx xx 00 00 00 00 00 00 00 00   |xxxxxxxx........|
00000020  00 00 00 00 00 00 01 36 01 38 yy yy xx xx 00 01   |.......6.8......|
```
... while "yy yy" is the amount of power to set down, "xx xx" the amount of power to increase.

What is still not clear:
When reconnecting to Growatt mqtt server (ACTIVATE_COMMUNICATION_GROWATT_SERVER) I observe following message:

```
=== ../../../dump/s/0PVPxxxxxxxxxxxx/1746110879534.bin ===
00000000  00 01 00 07 00 3B FE 18 30 50 56 50 xx xx xx xx   |.....;..0PVPxxxx|
00000010  xx xx xx xx xx xx xx xx 00 00 00 00 00 00 00 00   |xxxxxxxx........|
00000020  00 00 00 00 00 00 00 01 00 17 00 1F 00 13 32 30   |..............20|
00000030  32 35 2D 30 35 2D 30 31 20 31 36 3A 34 37 3A 35   |25-05-01 16:47:5|
00000040  39                                                |9|

{
  "msg_len": 59,
  "msg_type": 65048,
  "device_id": "0PVPxxxxxxxxxxxx",
  "payload": {
    "action": "slot_create",
    "slot": 0,
    "start": "31:00",
    "end": "19:50",
    "power": 13613
  }
}
```

So far, I did not manage to analyze the purpose of this message. Obviously, this does not seem to be a "slot_create" action. Do you have any idea?

Besides this, the next thing would be to make this configurable by MQTT / Home Assistant. Any preference on how to implement this?

- Home Assistant command topic
- own command topic (independant from HA)
- both
- something different?