### PR TITLE
Set Timeout for Device after last Ping

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -115,6 +115,7 @@ docker run --detach \
 | `ACTIVATE_COMMUNICATION_GROWATT_SERVER` | ❌ No    | Set to `true` to redirect messages to and from the Growatt Server. This is turned off by default. |
 | `LOG_LEVEL` | ❌ No    | Sets the logging level to either `ERROR`, `DEBUG`, or `INFO`. If not set `ERROR` is used. |
 | `DUMP_MESSAGES`      | ❌ No    | Dumps every received messages into `/dump` for later in-depth inspection. |
+| `DEVICE_TIMEOUT`      | ❌ No    | Set the timeout in seconds for the device communication. Default is 0 (disabled). Recommendation 300+ seconds. |
 
 # Example Setup with DuckDNS and HA-MQTT
 

--- a/config.yaml
+++ b/config.yaml
@@ -53,3 +53,4 @@ schema:
   LOG_LEVEL: list(INFO|ERROR|DEBUG)?
   DUMP_MESSAGES: "bool"
   DUMP_DIR: "str?"
+  DEVICE_TIMEOUT: "int?"

--- a/grobro/ha/client.py
+++ b/grobro/ha/client.py
@@ -75,6 +75,7 @@ class Client:
         payload = {
             "name": ha.get("name", variable),
             "state_topic": f"{HA_BASE_TOPIC}/grobro/{device_id}/state",
+            "availability_topic": f"{HA_BASE_TOPIC}/grobro/{device_id}/availability",
             "value_template": f"{{{{ value_json['{variable}'] }}}}",
             "unique_id": f"grobro_{device_id}_{variable}",
             "object_id": f"{device_id}_{variable}",
@@ -88,3 +89,6 @@ class Client:
     def publish_state(self, device_id, state):
         topic = f"{HA_BASE_TOPIC}/grobro/{device_id}/state"
         self.client.publish(topic, json.dumps(state), retain=False)
+    def publish_availability(self, device_id, state):
+        topic = f"{HA_BASE_TOPIC}/grobro/{device_id}/availability"
+        self.client.publish(topic, state, retain=False)

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -47,3 +47,6 @@ configuration:
   DUMP_DIR:
     name: DUMP_DIR
     description: Verzeichnis zum Speichern abgefangener Nachrichten. Standard ist /share/GroBro/dump. Im Addon muss es mit /share beginnen.
+  DEVICE_TIMEOUT:
+    name: DEVICE_TIMEOUT
+    description: Legt den Timeout in Sekunden fest, wann das Gerät als Nicht Verfügbar angezeigt wird. Default ist 0 (deaktiviert). Empfehlung 300+ Sekunden.

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -47,3 +47,6 @@ configuration:
   DUMP_DIR:
     name: DUMP_DIR
     description: Directory to store dumped messages. Default is /share/GroBro/dump. In Addon it has to start with /share
+  DEVICE_TIMEOUT:
+    name: DEVICE_TIMEOUT
+    description: Set the timeout in seconds for the device communication. Default is 0 (disabled). Recommendation 300+ seconds.


### PR DESCRIPTION
Initial setup of timeout (DEVICE_TIMEOUT) which will set the device to "unavailable" as requested in https://github.com/robertzaage/GroBro/issues/34
Default is 0 ,which means disabled (as before)

Currently the whole device will set to unavailable with this function.
