### PR TITLE
add armv7 architecture

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build and push to GHCR
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           file: ./Dockerfile
           push: true
           tags: ${{ env.TAGS }}


### PR DESCRIPTION
As described in https://github.com/robertzaage/GroBro/discussions/36, the desire for an ARMv7 image  has come up.
The Python base image supports this architecture.

