### PR TITLE
fix property wrapper for forwarded messages

### DIFF
--- a/grobro/grobro/client.py
+++ b/grobro/grobro/client.py
@@ -61,7 +61,7 @@ MQTT_PROP_FORWARD_GROWATT = mqtt.Properties(mqtt.PacketTypes.PUBLISH)
 MQTT_PROP_FORWARD_GROWATT.UserProperty = [("forwarded-for", "growatt")]
 # property to flag messages forwarded from ha
 MQTT_PROP_FORWARD_HA = mqtt.Properties(mqtt.PacketTypes.PUBLISH)
-MQTT_PROP_FORWARD_HA = [("forwarded-for", "ha")]
+MQTT_PROP_FORWARD_HA.UserProperty = [("forwarded-for", "ha")]
 
 
 class Client:


### PR DESCRIPTION
Hey @robertzaage ,

before you create the next release, I found a small bug.
The current mqtt client lib requires us to wrap properties into the Properties class.
Otherwise the publish will fail.