### PR TITLE
set Dataloggerintervall Neo - Initial

### DIFF
--- a/grobro/ha/growatt_neo_commands.json
+++ b/grobro/ha/growatt_neo_commands.json
@@ -10,5 +10,13 @@
   "output_power_limit_read": {
           "name": "Output Power Limit Read",
           "type": "button"
+  },
+  "datalogger_intervall": {
+          "name": "Datalogger Intervall",
+          "type": "number",
+          "unit_of_measurement": "minutes",
+          "min": 1,
+          "max": 10,
+          "step": 1
   }
 }


### PR DESCRIPTION
**## not ready yet**

Inital add of Datalogger Intervall from Neo Inverter (in minutes). Growatt initially set this to 5 minutes 

@gfelbing could you please take a look. I am not sure if I need parse_ha and parse_grobro here. Also the number in HA switches always to "6", so we need some logic here to store the last value

When command was sucessfull we get an answer from Inverter (msg-type 35 / 280 ) . I can provide it if you need it

Also Growatt cloud sometimes overwrites this value so maybe we can catch their command (optionally) and dont forward it.