### PR TITLE
Adding default power and reads for noah

### DIFF
--- a/grobro/grobro/client.py
+++ b/grobro/grobro/client.py
@@ -168,6 +168,8 @@ class Client:
                     for name, register in known_registers.holding_registers.items():
                         data_raw = modbus_message.get_data(register.growatt.position)
                         value = register.growatt.data.parse(data_raw)
+                        if value is None:
+                            continue
 
                         state.payload.append(
                             HomeAssistantHoldingRegisterValue(

--- a/grobro/ha/client.py
+++ b/grobro/ha/client.py
@@ -153,6 +153,17 @@ class Client:
                     )
                 )
                 return
+            if cmd_name == "default_power":
+                value = int(msg.payload.decode())
+                self.on_command(
+                    GrowattModbusFunctionSingle(
+                        device_id=device_id,
+                        function=GrowattModbusFunction.PRESET_SINGLE_REGISTER,
+                        register=252,
+                        value=value,
+                    )
+                )
+                return
 
 
             pos = known_registers.holding_registers[cmd_name].growatt.position

--- a/grobro/model/growatt_noah_registers.json
+++ b/grobro/model/growatt_noah_registers.json
@@ -1,6 +1,18 @@
 {
   "holding_registers": {
     "slot1_power": {
+      "growatt": {
+        "position": {
+          "register_no": 257 
+        },
+        "data": {
+          "data_type": "FLOAT",
+          "float_options": {
+            "delta": 0.0,
+            "multiplier": 1
+          }
+        }
+      },
       "homeassistant": {
         "publish": true,
         "name": "Slot 1 Power",
@@ -12,6 +24,18 @@
       }
     },
     "default_power": {
+      "growatt": {
+        "position": {
+          "register_no": 252
+        },
+        "data": {
+          "data_type": "FLOAT",
+          "float_options": {
+            "delta": 0.0,
+            "multiplier": 1
+          }
+        }
+      },
       "homeassistant": {
         "publish": true,
         "name": "Default Out Power",

--- a/grobro/model/growatt_noah_registers.json
+++ b/grobro/model/growatt_noah_registers.json
@@ -10,6 +10,17 @@
         "max": 800,
         "step": 1
       }
+    },
+    "default_power": {
+      "homeassistant": {
+        "publish": true,
+        "name": "Default Out Power",
+        "unit_of_measurement": "W",
+        "type": "number",
+        "min": 0,
+        "max": 800,
+        "step": 1
+      }
     }
   },
   "input_registers": {


### PR DESCRIPTION
I added the Default Out Power (when no slot is set/active) and also the reads for both values.

I think we should implement an automatic read of the register after we set it to a specific value.

Can somone please test this PR. My tests looks good. 
Maybe it also work for Nexa