### PR TITLE
Smart self-consumption mode added for the selection of slot modes for the Noah 2000

### DIFF
--- a/grobro/model/growatt_noah_registers.json
+++ b/grobro/model/growatt_noah_registers.json
@@ -58,7 +58,7 @@
             "name": "Slot 1 Mode",
             "type": "number",
             "min": 0,
-            "max": 1,
+            "max": 2,
             "step": 1
         }
     },


### PR DESCRIPTION
There are different modes for the time slots (register 256) for the Noah 2000 (presumably also for the NEXA). Two of these are already integrated (value 1 and 0). However, there is also the option of adding a smart electricity meter in the ShinePhone app (of course, the battery must be able to communicate with the Growatt Cloud for this, but the connection to the electricity meter runs locally and communication with the Growatt Cloud can be deactivated again afterwards). If you do this, there is a new mode for the time slots (smart self-consumption mode) through which the battery automatically adjusts its output power to the current power consumption. This mode can be activated by setting the value of register 256 to 2 for the respective time slot.

If this register is set to 2 although the smart self-consumption mode is not available (because no smart counter has been stored), nothing happens.

Unfortunately, I could not verify that this feature is also available for the Nexa2000 / that it works the same way as here, so this addition is only for the Noah for the time being.