### PR TITLE
Add signed values as data type

### DIFF
--- a/grobro/model/growatt_registers.py
+++ b/grobro/model/growatt_registers.py
@@ -10,8 +10,8 @@ class GrowattRegisterDataTypes(str, Enum):
     ENUM = "ENUM"
     STRING = "STRING"
     FLOAT = "FLOAT"
-    SIGNED_FLOAT = "SIGNED_FLOAT"
     INT = "INT"
+    SIGNED_FLOAT = "SIGNED_FLOAT"
     SIGNED_INT = "SIGNED_INT"
     TIME_HHMM = "TIME_HHMM"
 

--- a/grobro/model/growatt_registers.py
+++ b/grobro/model/growatt_registers.py
@@ -10,7 +10,9 @@ class GrowattRegisterDataTypes(str, Enum):
     ENUM = "ENUM"
     STRING = "STRING"
     FLOAT = "FLOAT"
+    SIGNED_FLOAT = "SIGNED_FLOAT"
     INT = "INT"
+    SIGNED_INT = "SIGNED_INT"
     TIME_HHMM = "TIME_HHMM"
 
 
@@ -38,7 +40,10 @@ class GrowattRegisterDataType(BaseModel):
         if not data_raw:
             return None
         unpack_type = {1: "!B", 2: "!H", 4: "!I"}[len(data_raw)]
-        if self.data_type == GrowattRegisterDataTypes.FLOAT:
+        is_signed = self.data_type in [GrowattRegisterDataTypes.SIGNED_INT, GrowattRegisterDataTypes.SIGNED_FLOAT]
+        if is_signed:
+            unpack_type = unpack_type.lower()
+        if self.data_type in [GrowattRegisterDataTypes.FLOAT, GrowattRegisterDataTypes.SIGNED_FLOAT]:
             opts = self.float_options
             value = struct.unpack(unpack_type, data_raw)[0]
             value *= opts.multiplier
@@ -49,7 +54,7 @@ class GrowattRegisterDataType(BaseModel):
             h = value // 256
             m = value % 256
             return (h * 100) + m
-        elif self.data_type == GrowattRegisterDataTypes.INT:
+        elif self.data_type in [GrowattRegisterDataTypes.INT, GrowattRegisterDataTypes.SIGNED_INT]:
             value = struct.unpack(unpack_type, data_raw)[0]
             return value
         elif self.data_type == GrowattRegisterDataTypes.ENUM:

--- a/grobro/model/growatt_spf_registers.json
+++ b/grobro/model/growatt_spf_registers.json
@@ -998,7 +998,7 @@
           "size": 4
         },
         "data": {
-          "data_type": "FLOAT",
+          "data_type": "SIGNED_FLOAT",
           "float_options": {
             "delta": 0.0,
             "multiplier": 0.1


### PR DESCRIPTION
After the addition of the registers for the SPF models, I noticed that one of the values (battery power) is actually exposed as signed int 32:

<img width="661" height="126" alt="Screenshot 2025-09-24 alle 23 25 48" src="https://github.com/user-attachments/assets/d893319e-3e4d-4aff-9b4f-3936c9c8d87b" />

Signed values are not supported at the moment, thus the data is wrongly read:

<img width="264" height="291" alt="Screenshot 2025-09-24 alle 23 28 07" src="https://github.com/user-attachments/assets/9bc107c2-66de-499d-9b68-09053413aaf6" />

(this value should be negative, but it is wrongly displayed as a very high value).

This PR adds support for signed int and signed float values, that can be used as data type in the registers definition using `SIGNED_INT` and `SIGNED_FLOAT`.
Negative values are properly interpreted and displayed in Home Assistant after this change:

<img width="301" height="143" alt="Screenshot 2025-09-24 alle 23 32 09" src="https://github.com/user-attachments/assets/578dcc2a-160b-44c1-87e4-fcc30203dea5" />
