### PR TITLE
Added options to expose device availability via dedicated online sensor and to send  sensor states retain via MQTT

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -114,9 +114,10 @@ docker run --detach \
 | `GROWATT_CLOUD`      | ❌ No    | Set to `true` to redirect messages to and from the Growatt Cloud. This is turned off by default. Supports a comma-separated list of device serials (e.g. `123456789,987654321`) for selective forwarding. |
 | `LOG_LEVEL`          | ❌ No    | Sets the logging level to either `ERROR`, `DEBUG`, or `INFO`. If not set `ERROR` is used. |
 | `DUMP_MESSAGES`      | ❌ No    | Dumps every received messages into `/dump` for later in-depth inspection. |
-| `DEVICE_TIMEOUT`     | ❌ No    | Set the timeout in seconds for the device communication. Default is 0 (disabled). Recommendation 300+ seconds. |
+| `DEVICE_TIMEOUT`     | ❌ No    | Set the timeout in seconds for the device communication. Default is 0 (disabled). Recommendation 300+ seconds.After this time the device and all its entities will be marked as unavailable in Home Assistant. |
+| `AVAILABILITY_SENSOR`     | ❌ No    | Set to `true` to expose device availability only as a dedicated `online` sensor instead of marking the device and all its entities unavailable after timeout. Default is `false`.  |
 | `MAX_SLOTS`     | ❌ No    | Set max available Slots for Battery configuration (Noah = max 9) |
-| `PUBLISH_SENSORS_RETAINED`     | ❌ No    | Publish sensor states with MQTT retain flag enabled(default false) |
+| `PUBLISH_SENSORS_RETAINED`     | ❌ No    | Set to `true` to publish sensor states with the MQTT retain flag enabled. Default is `false`.  |
 
 # Example Setup with DuckDNS and HA-MQTT
 

--- a/grobro/ha/client.py
+++ b/grobro/ha/client.py
@@ -27,6 +27,7 @@ from grobro.model.modbus_function import (
 
 HA_BASE_TOPIC = os.getenv("HA_BASE_TOPIC", "homeassistant")
 DEVICE_TIMEOUT = int(os.getenv("DEVICE_TIMEOUT", 0))
+AVAILABILITY_SENSOR = os.getenv("AVAILABILITY_SENSOR", "False").lower() == "true"
 PUBLISH_SENSORS_RETAINED = os.getenv("PUBLISH_SENSORS_RETAINED", "False").lower() == "true"
 MAX_SLOTS = int(os.getenv("MAX_SLOTS", "1"))
 LOG = logging.getLogger(__name__)
@@ -258,11 +259,18 @@ class Client:
 
     def __publish_availability(self, device_id: str, online: bool):
         LOG.debug("Set device %s availability: %s", device_id, online)
-        self._client.publish(
-            f"{HA_BASE_TOPIC}/grobro/{device_id}/availability",
-            "online" if online else "offline",
-            retain=True,
-        )
+        if (not online and not AVAILABILITY_SENSOR) or online:
+            self._client.publish(
+                f"{HA_BASE_TOPIC}/grobro/{device_id}/availability",
+                "online" if online else "offline",
+                retain=True,
+            )
+        if (AVAILABILITY_SENSOR):
+            self._client.publish(
+                f"{HA_BASE_TOPIC}/grobro/{device_id}/online",
+                "ON" if online else "OFF",
+                retain=PUBLISH_SENSORS_RETAINED,
+            )
 
     def __publish_device_discovery(self, device_id: str):
         known_registers = get_known_registers(device_id)
@@ -349,6 +357,16 @@ class Client:
             "object_id": f"{device_id}_type",
             "icon": "mdi:chip",
         }
+        # Online Entity
+        if DEVICE_TIMEOUT > 0 and AVAILABILITY_SENSOR:
+            payload["cmps"][f"grobro_{device_id}_online"] = {
+                "platform": "binary_sensor",
+                "name": "Online",
+                "state_topic": f"{HA_BASE_TOPIC}/grobro/{device_id}/online",
+                "device_class": "connectivity",
+                "unique_id": f"grobro_{device_id}_online",
+                "object_id": f"{device_id}_online",
+            }
 
         payload_str = json.dumps(payload, sort_keys=True, separators=(",", ":"))
 


### PR DESCRIPTION
I added this because I encountered an issue where, after restarting Home Assistant at night, all sensors became unavailable due to non-retained MQTT values. The dedicated online sensor allows me to still access the sensor data while knowing whether the device is offline. I believe these features will be useful for everyone.