### PR TITLE
Continue with local message processing if cloud forwarding fails

### DIFF
--- a/grobro/grobro/client.py
+++ b/grobro/grobro/client.py
@@ -120,7 +120,7 @@ class Client:
             LOG.warning("Sending failed: %s", result)
 
     def __on_connect(self, client, userdata, flags, reason_code, properties):
-      LOG.debug(f"Connected with result code {reason_code}")
+      LOG.debug(f"Connected to GroBro MQTT server with result code {reason_code}")
       self._client.subscribe("c/#")      
 
     def __on_message(self, client, userdata, msg: MQTTMessage):

--- a/grobro/ha/client.py
+++ b/grobro/ha/client.py
@@ -113,6 +113,7 @@ class Client:
                 topic = f"{HA_BASE_TOPIC}/{cmd_type}/grobro/+/+/{action}"
                 self._client.subscribe(topic)
         self._client.on_message = self.__on_message
+        self._client.on_connect = self.__on_connect
 
         # Configs laden (Cache aus Dateien)
         for fname in os.listdir("."):
@@ -182,6 +183,9 @@ class Client:
             LOG.error(f"HA: publish msg: {e}")
 
     # ------------------- MQTT Callback -------------------
+
+    def __on_connect(self, client, userdata, flags, reason_code, properties):
+        LOG.debug(f"Connected to HA MQTT server with result code {reason_code}")
 
     def __on_message(self, client, userdata, msg: mqtt.MQTTMessage):
         parts = msg.topic.removeprefix(f"{HA_BASE_TOPIC}/").split("/")


### PR DESCRIPTION
Sometimes the cloud servers are unstable. In that case just continue with local message processing and log the error. With that the local HA connectivity is kept functional.