### PR TITLE
Corrected Offset for Noah Bat temp

### DIFF
--- a/grobro/model/growatt_noah_registers.json
+++ b/grobro/model/growatt_noah_registers.json
@@ -1236,7 +1236,7 @@
         "data": {
           "data_type": "FLOAT",
           "float_options": {
-            "delta": -273,
+            "delta": -273.1,
             "multiplier": 0.1
           }
         }
@@ -1713,7 +1713,7 @@
         "data": {
           "data_type": "FLOAT",
           "float_options": {
-            "delta": -273,
+            "delta": -273.1,
             "multiplier": 0.1
           }
         }
@@ -1737,7 +1737,7 @@
         "data": {
           "data_type": "FLOAT",
           "float_options": {
-            "delta": -273,
+            "delta": -273.1,
             "multiplier": 0.1
           }
         }
@@ -1761,7 +1761,7 @@
         "data": {
           "data_type": "FLOAT",
           "float_options": {
-            "delta": -273,
+            "delta": -273.1,
             "multiplier": 0.1
           }
         }


### PR DESCRIPTION
After checking the raw values I found the resolution of the temp values is 1 kelvin, no digits between.
Corrected the offset from -273 to -273.1 to have full even numbers without digits for degree celsius shown in Home Assistant