### PR TITLE
Fix: Remove slot filter from read_all button to allow full state sync

### DIFF
--- a/grobro/ha/client.py
+++ b/grobro/ha/client.py
@@ -262,7 +262,7 @@ class Client:
             if cmd_name == "read_all":
 		# Send all modbus reads first
                 for name, register in known_registers.holding_registers.items():
-                    if name.startswith("slot"):
+                    
                         try:
                             if int(name[4]) > MAX_SLOTS:
                                 continue

--- a/grobro/ha/client.py
+++ b/grobro/ha/client.py
@@ -262,12 +262,6 @@ class Client:
             if cmd_name == "read_all":
 		# Send all modbus reads first
                 for name, register in known_registers.holding_registers.items():
-                    
-                        try:
-                            if int(name[4]) > MAX_SLOTS:
-                                continue
-                        except ValueError:
-                            continue
                     pos = register.growatt.position
                     self.on_command(make_modbus_command(
                         device_id,


### PR DESCRIPTION
The hardcoded 'startswith("slot")' filter prevented holding registers like switches (grid_power_allowed, etc.) and default_power from being read during a read_all command. Removing this filter enables proper state synchronization for all defined holding registers with smart home systems.