### PR TITLE
Add Inverter Power switch for NEO inverters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### New Features
++ NEO inverters now expose an **Inverter Power** switch (holding register 0). Sending OFF stops the inverter; ON re-enables it. This complements `output_power_limit` (register 3), which can't reach a true off due to the firmware enforcing a ~30 W floor at 0 %. Verified against a NEO 800M-X with GroBro running locally and no Growatt cloud session.
+
 ## v2.7.2
 
 ### New Features

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -188,3 +188,12 @@ Currently, dynamic adjustment of AC charging power (up to 700W) is handled entir
 *   Accidentally bypassing the native BMS and charging electronics limits can result in catastrophic hardware failure, severe thermal runaway, or an explosion/fire hazard. Let the native electronics make the final call on charging. 
 
 *(Note: The technical insights in this section were provided by a Growatt employee acting out of personal enthusiasm for the Home Assistant community. Growatt does not officially support this project at this time, and these insights do not represent official company directives).*
+
+### 4. NEO Inverter Power Switch (Register 0)
+The NEO holding-register map exposes an **Inverter Power** switch on register 0 (function `0x06` Modbus write, value `0x0000` = OFF, `0x0001` = ON). This is the same command Growatt's cloud sends when the user taps on/off in ShinePhone, and it works against the local broker without an active cloud session.
+
+Use it when you need a true off — the existing `output_power_limit` (Reg 3) enforces a hardware floor of ~30 W at 0 %, so it can't fully stop AC output. The on/off switch can.
+
+Caveats:
+*   EEPROM-wear characteristics of register 0 are not documented. Until verified, treat it as a coarse-grained control: occasional automation triggers (e.g., negative grid pricing, export caps), not high-frequency dynamic control. Use `output_power_limit` for continuous setpoint loops.
+*   After an OFF, the inverter takes several seconds to actually drop AC output (cloud-style command propagation delay). The HA-side `Inverter_Status` sensor (`StandbyStatus`/`NormalStatus`) reflects the real state.

--- a/grobro/model/growatt_neo_registers.json
+++ b/grobro/model/growatt_neo_registers.json
@@ -62,6 +62,24 @@
     }
   },
   "holding_registers": {
+    "inverter_power": {
+      "growatt": {
+        "position": {
+          "register_no": 0,
+          "offset": 0,
+          "size": 2
+        },
+        "data": {
+          "data_type": "INT"
+        }
+      },
+      "homeassistant": {
+        "publish": true,
+        "name": "Inverter Power",
+        "type": "switch",
+        "icon": "mdi:power"
+      }
+    },
     "output_power_limit": {
       "growatt": {
         "position": {


### PR DESCRIPTION
## Summary

Adds an **Inverter Power** switch entity to the NEO holding-register map. Writes register 0 with `1` = ON, `0` = OFF — the same command Growatt's cloud sends when the user taps the on/off button in ShinePhone.

This complements the existing `output_power_limit` (register 3), which can't reach a true off — the firmware enforces a ~30 W floor at 0 %.

## Why

Users want a hard "disable inverter" trigger from Home Assistant automations (e.g. negative grid pricing, export caps). Register 3 alone can't do that; register 0 can.

## How it was verified

1. Captured the cloud→inverter traffic on `s/33/<serial>` while toggling ShinePhone's on/off button. The downlink frame is a standard `PRESET_SINGLE_REGISTER` write (function `0x06`) to register 0 with value `0x0000` (off) or `0x0001` (on). Frame layout matches GroBro's existing `GrowattModbusFunctionSingle.build_grobro` output byte-for-byte.
2. Built a standalone publisher that synthesizes the same frame from scratch; confirmed identical bytes against the capture.
3. Verified the inverter accepts the command:
   - while logged in to ShinePhone ✓
   - while logged out of ShinePhone ✓
   - via direct MQTT publish on the local broker (no Growatt cloud involvement) ✓
4. Verified that the HA discovery already wires `type: switch` end-to-end (precedent: NEXA `Grid Power Allowed` and the slot-enabled switches in `growatt_nexa_registers.json`). No Python changes required.

Tested with a Growatt NEO 800M-X (datalogger serial prefix `QMN`).

## Notes / open follow-ups

- After a write to register 0, GroBro's existing read-after-write path (`ha/client.py:428-430`) issues a `READ_SINGLE_REGISTER` on register 0. I haven't confirmed whether the inverter responds to that read; if it doesn't, the switch state may briefly show as unknown until the next manual toggle. The HA-side `Inverter_Status` sensor (`StandbyStatus` vs `NormalStatus`) reflects the real state regardless and can be used as an availability template if it matters.
- The change is data-only (one JSON entry + a `CHANGELOG.md` note + a `CONFIGURATION.md` note in the Hardware Safety section). No code changes, no tests touched.

## Test plan

- [ ] Pull the branch, restart GroBro.
- [ ] In HA, see a new `switch.<serial>_inverter_power` entity.
- [ ] Toggle off → inverter `Pac` drops to 0 within ~10 s.
- [ ] Toggle on → inverter resumes producing.
- [ ] (Maintainer) verify the EEPROM-wear note in `CONFIGURATION.md` is worded appropriately for register 0 — happy to adjust if you have better info.
