### PR TITLE
Add Firmware Register for Nexa and Noah

### DIFF
--- a/grobro/ha/client.py
+++ b/grobro/ha/client.py
@@ -641,6 +641,31 @@ class Client:
                     "icon": "mdi:identifier",
                 }
 
+        # Combined firmware version (NOAH = 3 parts, NEXA = 4 parts)
+        fw_parts = sorted(
+            name
+            for name in known_registers.input_registers
+            if name.startswith("fw_part_")
+        )
+
+        if fw_parts:
+            combined_name = "firmware_version"
+            firmware_unique_id = f"grobro_{device_id}_{combined_name}"
+
+            value_template = ".".join(
+                f"{{{{ value_json['{part}'] }}}}"
+                for part in fw_parts
+            )
+
+            payload["cmps"][firmware_unique_id] = {
+                "platform": "sensor",
+                "name": "Firmware Version",
+                "state_topic": f"{HA_BASE_TOPIC}/grobro/{device_id}/state",
+                "value_template": value_template,
+                "unique_id": firmware_unique_id,
+                "icon": "mdi:information",
+            }
+
         # Serial Number Entity
         serial_unique_id = f"grobro_{device_id}_serial"
         payload["cmps"][serial_unique_id] = {

--- a/grobro/ha/client.py
+++ b/grobro/ha/client.py
@@ -642,19 +642,19 @@ class Client:
                 }
 
         # Combined firmware version (NOAH = 3 parts, NEXA = 4 parts)
-        fw_parts = sorted(
+        fw_version_parts = sorted(
             name
             for name in known_registers.input_registers
-            if name.startswith("fw_part_")
+            if name.startswith("fw_version_part_")
         )
 
-        if fw_parts:
+        if fw_version_parts:
             combined_name = "firmware_version"
             firmware_unique_id = f"grobro_{device_id}_{combined_name}"
 
             value_template = ".".join(
                 f"{{{{ value_json['{part}'] }}}}"
-                for part in fw_parts
+                for part in fw_version_parts
             )
 
             payload["cmps"][firmware_unique_id] = {

--- a/grobro/ha/client.py
+++ b/grobro/ha/client.py
@@ -649,7 +649,7 @@ class Client:
         )
 
         if fw_version_parts:
-            combined_name = "firmware_version"
+            combined_name = "fw_version"
             firmware_unique_id = f"grobro_{device_id}_{combined_name}"
 
             value_template = ".".join(

--- a/grobro/model/growatt_nexa_registers.json
+++ b/grobro/model/growatt_nexa_registers.json
@@ -2256,7 +2256,7 @@
       },
       "homeassistant": {
         "name": "Firmware Version Part 1",
-        "publish": true,
+        "publish": false,
         "icon": "mdi:information"
       }
     },
@@ -2273,7 +2273,7 @@
       },
       "homeassistant": {
         "name": "Firmware Version Part 2",
-        "publish": true,
+        "publish": false,
         "icon": "mdi:information"
       }
     },
@@ -2290,7 +2290,7 @@
       },
       "homeassistant": {
         "name": "Firmware Version Part 3",
-        "publish": true,
+        "publish": false,
         "icon": "mdi:information"
       }
     },
@@ -2307,7 +2307,7 @@
       },
       "homeassistant": {
         "name": "Firmware Version Part 4",
-        "publish": true,
+        "publish": false,
         "icon": "mdi:information"
       }
     }

--- a/grobro/model/growatt_nexa_registers.json
+++ b/grobro/model/growatt_nexa_registers.json
@@ -2242,6 +2242,74 @@
         "state_class": "measurement",
         "icon": "mdi:thermometer"
       }
+    },
+    "fw_part_1": {
+      "growatt": {
+        "position": {
+          "register_no": 119,
+          "offset": 0,
+          "size": 1
+        },
+        "data": {
+          "data_type": "INT"
+        }
+      },
+      "homeassistant": {
+        "name": "Firmware Part 1",
+        "publish": true,
+        "icon": "mdi:information"
+      }
+    },
+    "fw_part_2": {
+      "growatt": {
+        "position": {
+          "register_no": 119,
+          "offset": 1,
+          "size": 1
+        },
+        "data": {
+          "data_type": "INT"
+        }
+      },
+      "homeassistant": {
+        "name": "Firmware Part 2",
+        "publish": true,
+        "icon": "mdi:information"
+      }
+    },
+    "fw_part_3": {
+      "growatt": {
+        "position": {
+          "register_no": 120,
+          "offset": 0,
+          "size": 1
+        },
+        "data": {
+          "data_type": "INT"
+        }
+      },
+      "homeassistant": {
+        "name": "Firmware Part 3",
+        "publish": true,
+        "icon": "mdi:information"
+      }
+    },
+    "fw_part_4": {
+      "growatt": {
+        "position": {
+          "register_no": 120,
+          "offset": 1,
+          "size": 1
+        },
+        "data": {
+          "data_type": "INT"
+        }
+      },
+      "homeassistant": {
+        "name": "Firmware Part 4",
+        "publish": true,
+        "icon": "mdi:information"
+      }
     }
   }
 }

--- a/grobro/model/growatt_nexa_registers.json
+++ b/grobro/model/growatt_nexa_registers.json
@@ -2243,7 +2243,7 @@
         "icon": "mdi:thermometer"
       }
     },
-    "fw_part_1": {
+    "fw_version_part_1": {
       "growatt": {
         "position": {
           "register_no": 119,
@@ -2255,12 +2255,12 @@
         }
       },
       "homeassistant": {
-        "name": "Firmware Part 1",
+        "name": "Firmware Version Part 1",
         "publish": true,
         "icon": "mdi:information"
       }
     },
-    "fw_part_2": {
+    "fw_version_part_2": {
       "growatt": {
         "position": {
           "register_no": 119,
@@ -2272,12 +2272,12 @@
         }
       },
       "homeassistant": {
-        "name": "Firmware Part 2",
+        "name": "Firmware Version Part 2",
         "publish": true,
         "icon": "mdi:information"
       }
     },
-    "fw_part_3": {
+    "fw_version_part_3": {
       "growatt": {
         "position": {
           "register_no": 120,
@@ -2289,12 +2289,12 @@
         }
       },
       "homeassistant": {
-        "name": "Firmware Part 3",
+        "name": "Firmware Version Part 3",
         "publish": true,
         "icon": "mdi:information"
       }
     },
-    "fw_part_4": {
+    "fw_version_part_4": {
       "growatt": {
         "position": {
           "register_no": 120,
@@ -2306,7 +2306,7 @@
         }
       },
       "homeassistant": {
-        "name": "Firmware Part 4",
+        "name": "Firmware Version Part 4",
         "publish": true,
         "icon": "mdi:information"
       }

--- a/grobro/model/growatt_noah_registers.json
+++ b/grobro/model/growatt_noah_registers.json
@@ -1934,7 +1934,7 @@
       },
       "homeassistant": {
         "name": "Firmware Version Part 1",
-        "publish": true,
+        "publish": false,
         "icon": "mdi:information"
       }
     },
@@ -1951,7 +1951,7 @@
       },
       "homeassistant": {
         "name": "Firmware Version Part 2",
-        "publish": true,
+        "publish": false,
         "icon": "mdi:information"
       }
     },
@@ -1968,7 +1968,7 @@
       },
       "homeassistant": {
         "name": "Firmware Version Part 3",
-        "publish": true,
+        "publish": false,
         "icon": "mdi:information"
       }
     }

--- a/grobro/model/growatt_noah_registers.json
+++ b/grobro/model/growatt_noah_registers.json
@@ -1921,7 +1921,7 @@
         "icon": "mdi:counter"
       }
     },
-    "fw_part_1": {
+    "fw_version_part_1": {
       "growatt": {
         "position": {
           "register_no": 119,
@@ -1933,12 +1933,12 @@
         }
       },
       "homeassistant": {
-        "name": "Firmware Part 1",
+        "name": "Firmware Version Part 1",
         "publish": true,
         "icon": "mdi:information"
       }
     },
-    "fw_part_2": {
+    "fw_version_part_2": {
       "growatt": {
         "position": {
           "register_no": 119,
@@ -1950,12 +1950,12 @@
         }
       },
       "homeassistant": {
-        "name": "Firmware Part 2",
+        "name": "Firmware Version Part 2",
         "publish": true,
         "icon": "mdi:information"
       }
     },
-    "fw_part_3": {
+    "fw_version_part_3": {
       "growatt": {
         "position": {
           "register_no": 120,
@@ -1967,7 +1967,7 @@
         }
       },
       "homeassistant": {
-        "name": "Firmware Part 3",
+        "name": "Firmware Version Part 3",
         "publish": true,
         "icon": "mdi:information"
       }

--- a/grobro/model/growatt_noah_registers.json
+++ b/grobro/model/growatt_noah_registers.json
@@ -1920,6 +1920,57 @@
         "publish": true,
         "icon": "mdi:counter"
       }
+    },
+    "fw_part_1": {
+      "growatt": {
+        "position": {
+          "register_no": 119,
+          "offset": 0,
+          "size": 1
+        },
+        "data": {
+          "data_type": "INT"
+        }
+      },
+      "homeassistant": {
+        "name": "Firmware Part 1",
+        "publish": true,
+        "icon": "mdi:information"
+      }
+    },
+    "fw_part_2": {
+      "growatt": {
+        "position": {
+          "register_no": 119,
+          "offset": 1,
+          "size": 1
+        },
+        "data": {
+          "data_type": "INT"
+        }
+      },
+      "homeassistant": {
+        "name": "Firmware Part 2",
+        "publish": true,
+        "icon": "mdi:information"
+      }
+    },
+    "fw_part_3": {
+      "growatt": {
+        "position": {
+          "register_no": 120,
+          "offset": 0,
+          "size": 1
+        },
+        "data": {
+          "data_type": "INT"
+        }
+      },
+      "homeassistant": {
+        "name": "Firmware Part 3",
+        "publish": true,
+        "icon": "mdi:information"
+      }
     }
   }
 }


### PR DESCRIPTION
Adds sensors for the firmware of Noah and Nexa devices.

It could be used to build a full version string in the future, see https://github.com/robertzaage/GroBro/issues/200

Note that Noah firmware has 3 parts and Nexa firmware has 4 parts.

Nexa:

<img width="280" height="242" alt="image" src="https://github.com/user-attachments/assets/daa60f22-754a-4acf-b4e4-656b90bb561b" />
