### PR TITLE
Don't limit Ecotracker debug to 80 characters

### DIFF
--- a/grobro/grobro/client.py
+++ b/grobro/grobro/client.py
@@ -362,7 +362,7 @@ class Client:
             # NOAH EcoTracker JSON data (0x6F64)
             if msg_type == 0x6F64:
                 eco = parser.parse_noah_6f64(unscrambled)
-                LOG.debug("EcoTracker data for %s: %s", eco["device_id"], eco["data"][:80])
+                LOG.debug("EcoTracker data for %s: %s", eco["device_id"], eco["data"])
                 topic = f"{HA_BASE_TOPIC}/sensor/grobro/{eco['device_id']}/eco_tracker/state"
                 self._client.publish(topic, eco["data"], retain=PUBLISH_SENSORS_RETAINED)
                 return


### PR DESCRIPTION
The Ecotracker debug limited to 80 characters. I think it would be helpful to log the whole payload.

2026-06-28 21:22:00,155 [DEBUG] EcoTracker data for deviceId: {"manu":"everhome","model":"EcoTracker","sn":"sn","access":0,"comm_sts

With proposed change:

2026-06-28 21:37:00,150 [DEBUG] EcoTracker data for deviceId: {"manu":"everhome","model":"EcoTracker","sn":"sn","access":0,"comm_sts":1,"op_sts":1,"alarm":0,"t_act":-10,"t_avg":-3,"t_ae_pos":19187.376,"t_ae_neg":129.517,"err":0}
