### PR TITLE
Don't publish Nexa serial parts to Home Assistant

### DIFF
--- a/grobro/model/growatt_nexa_registers.json
+++ b/grobro/model/growatt_nexa_registers.json
@@ -1347,7 +1347,7 @@
       },
       "homeassistant": {
         "name": "Serial Part 1",
-        "publish": true,
+        "publish": false,
         "icon": "mdi:identifier"
       }
     },
@@ -1364,7 +1364,7 @@
       },
       "homeassistant": {
         "name": "Serial Part 2",
-        "publish": true,
+        "publish": false,
         "icon": "mdi:identifier"
       }
     },
@@ -1381,7 +1381,7 @@
       },
       "homeassistant": {
         "name": "Serial Part 3",
-        "publish": true,
+        "publish": false,
         "icon": "mdi:identifier"
       }
     },
@@ -1398,7 +1398,7 @@
       },
       "homeassistant": {
         "name": "Serial Part 4",
-        "publish": true,
+        "publish": false,
         "icon": "mdi:identifier"
       }
     },


### PR DESCRIPTION
This stops publishing the serial number parts 1 - 4 of the Nexa 2000 as separate sensors to Home Assistant. There is already a sensor with the full serial number.