### PR TITLE
Make Noah Message 0x6F64 generic for different Smart Meters

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -202,10 +202,10 @@ Dispatch priority in `__on_message`:
 | 1 | Config TLV | 340, 341, 387 | NEO, NOAH | `parser.parse_config_type` → `on_config(device_id, config)` |
 | 2 | Config read response | 281 | All | `parser.parse_config_message` → `on_config_read_response` |
 | 3 | Config write ack | 280 | All | Logged, no callback |
-| 4 | NOAH FE19 config | 0xFE19 | NOAH only | `parser.parse_noah_fe19` → `on_config(device_id, config)` |
+| 4 | NOAH FE19 config | 0xFE19 | NOAH, NEXA | `parser.parse_noah_fe19` → `on_config(device_id, config)` |
 | 5 | ShineWeLink config | 0x0129 (297) | ShineWeLink | `parser.parse_config_type` → `on_config(device_id, config)` |
 | 6 | Other NOAH subtypes | 0x0103–0xFE25 | NOAH / ShineWeLink | Dispatched to NOAH sub-parsers (see §2.7.2) |
-| 7 | EcoTracker JSON | 0x6F64 | NOAH | Published to raw MQTT topic |
+| 7 | Smart Meter JSON | 0x6F64 | NOAH, NEXA | Published to raw MQTT topic |
 | 8 | Generic modbus | 3, 4, 5, 6, 16, 100 | All | `GrowattModbusMessage.parse_grobro` → routed by function code |
 
 The `function` field at byte 7 determines the modbus function:
@@ -308,7 +308,7 @@ The payload always begins with 14 zero bytes.
 | `0xFE18` | `parse_noah_fe18` | Datetime set command / response |
 | `0xFE19` | `parse_noah_fe19` | Device config (subtype `0x0020`) or status (subtype `0x0001`) |
 | `0xFE25` | `parse_noah_fe25` | Heartbeat / keepalive (all zeros) |
-| `0x6F64` | `parse_noah_6f64` | EcoTracker JSON data |
+| `0x6F64` | `parse_noah_6f64` | Smart Meter (EcoTracker, Shelly etc.) JSON data |
 
 #### 2.7.2 FE19 config / status
 
@@ -325,7 +325,7 @@ FE19 is the most complex NOAH message type. The payload after the NOAH marker is
 - **Dev status** (subtype `0x0001`): A shorter TLV without the serial_number key. The
   `if config and config.serial_number` guard prevents `on_config` from being called.
 
-Only NOAH devices (serial prefix `0PVP`) reach this handler — RAQ FE19 messages
+Only NOAH (serial prefix `0PVP`) and NEXA devices (serial prefix `0HVR`) reach this handler — RAQ FE19 messages
 fall through to the modbus handler instead.
 
 **TLV offset heuristic** (`find_config_offset`): Scans the payload starting at byte `0x1C`

--- a/grobro/grobro/client.py
+++ b/grobro/grobro/client.py
@@ -359,12 +359,12 @@ class Client:
                 )
                 return
 
-            # NOAH/NEXA EcoTracker JSON data (0x6F64)
+            # NOAH/NEXA Smart Meter (EcoTracker, Shelly etc.) JSON data (0x6F64)
             if msg_type == 0x6F64:
-                eco = parser.parse_noah_6f64(unscrambled)
-                LOG.debug("EcoTracker data for %s: %s", eco["device_id"], eco["data"])
-                topic = f"{HA_BASE_TOPIC}/sensor/grobro/{eco['device_id']}/eco_tracker/state"
-                self._client.publish(topic, eco["data"], retain=PUBLISH_SENSORS_RETAINED)
+                smart_meter = parser.parse_noah_6f64(unscrambled)
+                LOG.debug("Smart Meter data for %s: %s", smart_meter["device_id"], smart_meter["data"])
+                topic = f"{HA_BASE_TOPIC}/sensor/grobro/{smart_meter['device_id']}/smart_meter/state"
+                self._client.publish(topic, smart_meter["data"], retain=PUBLISH_SENSORS_RETAINED)
                 return
 
             # NOAH/NEXA-specific message types (FE19 config, 0103 holding regs, etc.)

--- a/grobro/grobro/parser.py
+++ b/grobro/grobro/parser.py
@@ -288,18 +288,18 @@ def parse_noah_fe25(data: bytes) -> dict:
 
 def parse_noah_6f64(data: bytes) -> dict:
     """
-    NOAH type 0x6F64 (28516) — EcoTracker JSON data.
+    NOAH type 0x6F64 (28516) — Smart Meter (EcoTracker, Shelly etc.) JSON data.
     Structure:
         [0:8]   - header (2B unknown, 2B const7, 2B len, 2B msg_type)
         [8:38]  - device ID (30B ASCII, zero-padded)
-        [38:68] - EcoTracker serial (30B ASCII, zero-padded)
+        [38:68] - Smart Meter serial (30B ASCII, zero-padded)
         [68:75] - timestamp (7B: year-2000, month, day, hour, minute, second, millis)
         [75:79] - JSON length (4B big-endian)
         [79:-2] - JSON data
         [-2:]   - checksum (ignored)
     """
     device_id = data[8:38].rstrip(b"\x00").decode("ascii", errors="replace")
-    eco_sn = data[38:68].rstrip(b"\x00").decode("ascii", errors="replace")
+    smart_meter_sn = data[38:68].rstrip(b"\x00").decode("ascii", errors="replace")
     year_b, month, day, hour, minute, second, millis = struct.unpack_from(">BBBBBBB", data, 68)
     json_len = struct.unpack_from(">I", data, 75)[0]
     json_bytes = data[79:79 + json_len]
@@ -307,7 +307,7 @@ def parse_noah_6f64(data: bytes) -> dict:
     return {
         "message_type": 0x6F64,
         "device_id": device_id,
-        "eco_tracker_sn": eco_sn,
+        "smart_meter_sn": smart_meter_sn,
         "timestamp": f"{2000 + year_b:04d}-{month:02d}-{day:02d}T{hour:02d}:{minute:02d}:{second:02d}.{millis:03d}",
         "json_length": json_len,
         "data": json_str,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -23,7 +23,7 @@ def test_parse_noah_6f64():
     result = parser.parse_noah_6f64(bytes(data))
     assert result["message_type"] == 0x6F64
     assert result["device_id"] == device_id
-    assert result["eco_tracker_sn"] == eco_sn
+    assert result["smart_meter_sn"] == eco_sn
     assert "2026-05-15T17:12:09.001" in result["timestamp"]
     assert json.loads(result["data"])["t_act"] == 150
 


### PR DESCRIPTION
As mentioned in https://github.com/robertzaage/GroBro/issues/217, the Noah Message 0x6F64 is not EcoTracker specific, but used also for other smart meters (Shelly).