### PR TITLE
Add Wifi Signal Strength sensor for Noah and Nexa

### DIFF
--- a/grobro/model/growatt_nexa_registers.json
+++ b/grobro/model/growatt_nexa_registers.json
@@ -100,6 +100,23 @@
         "type": "text",
         "icon": "mdi:clock-outline"
       }
+    },
+    "wifi_signal_strength": {
+      "growatt": {
+        "register_no": 76,
+        "data": {
+          "data_type": "INT"
+        }
+      },
+      "homeassistant": {
+        "publish": true,
+        "name": "Wi-Fi Signal Strength",
+        "type": "sensor",
+        "state_class": "measurement",
+        "device_class": "signal_strength",
+        "unit_of_measurement": "dBm",
+        "icon": "mdi:wifi"
+      }
     }
   },
   "holding_registers": {

--- a/grobro/model/growatt_noah_registers.json
+++ b/grobro/model/growatt_noah_registers.json
@@ -73,6 +73,23 @@
         "type": "text",
         "icon": "mdi:clock-outline"
       }
+    },
+    "wifi_signal_strength": {
+      "growatt": {
+        "register_no": 76,
+        "data": {
+          "data_type": "INT"
+        }
+      },
+      "homeassistant": {
+        "publish": true,
+        "name": "Wi-Fi Signal Strength",
+        "type": "sensor",
+        "state_class": "measurement",
+        "device_class": "signal_strength",
+        "unit_of_measurement": "dBm",
+        "icon": "mdi:wifi"
+      }
     }
   },
   "holding_registers": {


### PR DESCRIPTION
As requested by @meiser79 in https://github.com/robertzaage/GroBro/issues/221

I don't think it's going to be too helpful as it's taken from the config message which is not send very often. Shouldn't hurt either way

<img width="341" height="124" alt="image" src="https://github.com/user-attachments/assets/e19df836-9996-476a-8283-cec8bf10fe01" />
