### PR TITLE
Fix Description for Default Smart Mode Enabled switch for Nexa

### DIFF
--- a/grobro/model/growatt_nexa_registers.json
+++ b/grobro/model/growatt_nexa_registers.json
@@ -1129,7 +1129,7 @@
       },
       "homeassistant": {
         "publish": true,
-        "name": "Smart Mode Enabled (?)",
+        "name": "Default Smart Mode Enabled",
         "type": "switch"
       }
     },


### PR DESCRIPTION
I have verified that the switch is for enabling or disabling smart mode when no time plan is active

<img width="1080" height="2180" alt="Screenshot_20260808_131006_ShinePhone" src="https://github.com/user-attachments/assets/6231642e-d450-437a-8174-829610b85c0e" />
